### PR TITLE
Agregar cambio de color de texto en menu de gestion de propietarios y historial clinico, Agrega validacion de fecha en agregar historial clinico

### DIFF
--- a/historia.cpp
+++ b/historia.cpp
@@ -8,9 +8,10 @@
 using namespace std;
 
 void agregarActualizarHistoria() {
-	int id;
+	string p;
 	int indice;
 	int selec;
+	int cantidadCaracteres;
 	system("cls");
 	for (int i=0;i<cantidaddepropietarios;i++) {
 		cout<<"PROPIETARIO "<<i+1<<":\n";
@@ -42,8 +43,23 @@ void agregarActualizarHistoria() {
 	cout<<"\nPLAN DE SEGUIMIENTO\n"<<endl
 		<<"Recomendaciones:"<<endl;
 	getline(cin,propietarios[indice].mascot.historial.planSeguimiento.recomendaciones);
-	cout<<"Proxima cita:"<<endl;
-	getline(cin,propietarios[indice].mascot.historial.planSeguimiento.proximaCita);
+	//Este bucle es Validacion, permitira volver a preguntar la fecha al usuario.
+	do{ 
+		cout<<"Proxima cita (DD/MM/YYYY):"<<endl;
+		getline(cin,propietarios[indice].mascot.historial.planSeguimiento.proximaCita);
+		p=propietarios[indice].mascot.historial.planSeguimiento.proximaCita;
+		cantidadCaracteres = p.length();
+		
+		//Esto valida que la fecha tenga '/'
+		if (p[2]!= '/' || p[5] != '/'){ 
+			cantidadCaracteres = 9; // se da 9 para volver al bucle
+		}
+		if(cantidadCaracteres != 10){  //Esto es para el error en el caso de que sea diferente de 10.
+			cout << "\nError fecha invalida, INGRESE DE NUEVO.\n\n";
+		}
+	}while(cantidadCaracteres != 10); //El bucle finaliza cuando cantidaCaracteres es 10.
+	
+	//continua con el registro del historial
 	cout<<"Nota del veterinario:"<<endl;
 	getline(cin,propietarios[indice].mascot.historial.notasVeterinario);
 	system("pause");

--- a/menu.cpp
+++ b/menu.cpp
@@ -17,12 +17,14 @@ void Menu() {
     int op;
     do {
         system("cls");
+        SetConsoleTextAttribute(hConsole, 7);
         cout << "\nSistema de gestión veterinaria\n\n";
         cout << "1. Gestión de Mascotas" << endl;
+        SetConsoleTextAttribute(hConsole, 9);
         cout << "2. Gestion de Propietario" << endl;
         SetConsoleTextAttribute(hConsole, 10);
         cout << "3. Gestion Inventario " << endl;
-        SetConsoleTextAttribute(hConsole, 7);
+        SetConsoleTextAttribute(hConsole, 3);
         cout << "4. Historial clinico " << endl;
         SetConsoleTextAttribute(hConsole, 6);
         cout << "5. Registro de Ventas " << endl;
@@ -64,6 +66,7 @@ void menuPropietario() {
     int opcion;
     do {
     	system("cls");
+    	SetConsoleTextAttribute(hConsole, 9);
         cout << "\nGestión de Propietarios\n\n";
         cout << "1. Agregar Propietario\n";
         cout << "2. Listar Propietarios\n";
@@ -174,6 +177,7 @@ void menuHistorial() {
 int opcion;
     do {
     	system("cls");
+    	SetConsoleTextAttribute(hConsole, 3);
         cout << "\nHistorial clinico\n\n";
         cout << "1. Agregar o actualziar historial clinico\n";
         cout << "2. Listar historiales clinicos\n";


### PR DESCRIPTION
-Se realizo un cambio de color en el texto de los menú de gestión de propietarios y historial clínico
-Se agrego un proceso para validación de entrada de fecha en agregar o actualizar historial clínico